### PR TITLE
Fix branch name when cloning from multidev

### DIFF
--- a/src/Commands/SiteCloneCommand.php
+++ b/src/Commands/SiteCloneCommand.php
@@ -371,9 +371,9 @@ class SiteCloneCommand extends SingleBackupCommand implements RequestAwareInterf
                 }
                 
                 if( false === in_array( $destination['env'], ['dev','test','live'] ) ){
-                    $this->passthru("git -C $git_dir checkout " . $destination_git_branch);
-                    $this->passthru("git -C $git_dir fetch origin " . $destination_git_branch);
-                    $this->passthru("git -C $git_dir merge origin/" . $destination_git_branch);
+                    $this->passthru("git -C $git_dir checkout " . $source_git_branch);
+                    $this->passthru("git -C $git_dir fetch origin " . $source_git_branch);
+                    $this->passthru("git -C $git_dir merge origin/" . $source_git_branch);
                 }
 
                 $this->log()->notice(


### PR DESCRIPTION
In trying to test https://github.com/pantheon-systems/terminus-site-clone-plugin/pull/3, I ran into a different error related to multidev names:

```
error: pathspec '123' did not match any file(s) known to git.
 [error]  Command `git -C /Users/stevepersch/.terminus/plugins/terminus-site-clone-plugin/terminus-site-clone-temp/bitb-persch/ checkout 123` failed with exit code 1
```

The command I ran was

```
 terminus site:clone bitb-persch.umami   d8-papc.123 --database --backup
```

This pull request updates the branch name used when checking out the source code.
