### PR TITLE
Test that an array element exists to silence a PHP Notice

### DIFF
--- a/src/Commands/SiteCloneCommand.php
+++ b/src/Commands/SiteCloneCommand.php
@@ -114,7 +114,7 @@ class SiteCloneCommand extends SingleBackupCommand implements RequestAwareInterf
 
         $confirmation_message = 'Are you sure you want to clone from the {src}.{src_env} environment (source) to the {dest}.{dest_env} (destination)? This will completely destroy the destination.';
 
-        if( $this->options['backup'] ){
+        if( ! empty( $this->options['backup'] ) ){
             $confirmation_message .= ' A backup will be made first, just in case.';
         }
 


### PR DESCRIPTION
This PR adds an `empty()` test around `$this->options['backup']` to silence the following PHP Notice:

* Notice: Undefined index: backup in $HOME/.terminus/plugins/terminus-site-clone-plugin/src/Commands/SiteCloneCommand.php on line 117

